### PR TITLE
Configurable backups

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -14,9 +14,9 @@ dirs = [
     "/path/to/project1",
     "/path/to/project2",
 ]                            # Directories to backup
-
 storage_path = "./backups/"  # Path to store backup files
 backup_prefix = "backup"     # Prefix for backup filenames
+cron_schedule = "0 0 1 * *"  # Cron schedule for automated backups
 
 [auth]
 password_hash = "XXXXXXXXX"  # Password hash in bcrypt


### PR DESCRIPTION
#Hello :wave: 
I'm opening this PR to resolve #2 

To make the changes i started by following the steps described in issue #2
Then i tried to add other changes that i thought were useful :

- I added an error handling to check if the cron provided in the config is compliant with the CRON format
  To do this, i used the [ParseStandard](https://pkg.go.dev/github.com/robfig/cron/v3#ParseStandard) function.
  ```go
  cronSchedule := config.Backup.CronSchedule
  if _, err := cron.ParseStandard(config.Backup.CronSchedule); err != nil {
  	  log.Fatalf("Invalid Cron Expression %v", err)
  }
  ```
  I put a **Fatal** error because backups cannot be executed if the cron is not correctly defined.

  Otherwise, i think it would be possible to consider having a default value, which would take the place when the CRON is not valid.
  Maybe this could be a more global feature request : "_add default values ​​on each value of the configuration_" :thinking: 


- I also added hours, minutes and seconds in the format.
  ```go
  date := time.Now().Format("02-01-2006T15:04:05")
  ```
  In case a user wants a backup every _x_ hours, minutes or seconds, i think it will be useful to have these fields in the file names.

- I also updated the comment and log message that mentioned "Monthly" to be more generic.
---

I hope this meets your needs ! Let me know if any adjustments are required :smile: 
#2  